### PR TITLE
Add gauge basics core and introduce radial gauge core

### DIFF
--- a/modules/CompassGauge/CompassGauge.js
+++ b/modules/CompassGauge/CompassGauge.js
@@ -25,7 +25,10 @@
   "use strict";
 
   function create(def, Helpers) {
-    const Polar = Helpers.getModule('PolarCore') && Helpers.getModule('PolarCore').create();
+    const PolarModule = Helpers.getModule('PolarCore');
+    const Polar = PolarModule && typeof PolarModule.create === 'function'
+      ? PolarModule.create(def, Helpers)
+      : undefined;
 
     // ---------- utils --------------------------------------------------------
     function setFont(ctx, px, bold, family){ ctx.font = (bold ? '700 ' : '400 ') + px + 'px ' + family; }

--- a/modules/Cores/GaugeBasicsCore.js
+++ b/modules/Cores/GaugeBasicsCore.js
@@ -1,0 +1,284 @@
+/*!
+ * GaugeBasicsCore (UMD) — shared math + drawing primitives for gauges
+ */
+(function (root, factory) {
+  if (typeof define === "function" && define.amd) define([], factory);
+  else if (typeof module === "object" && module.exports) module.exports = factory();
+  else { (root.DyniModules = root.DyniModules || {}).DyniGaugeBasicsCore = factory(); }
+}(this, function () {
+  "use strict";
+
+  function create(def, Helpers) {
+    // ---- math helpers -------------------------------------------------------
+    function clamp(value, min, max){
+      const v = Number(value);
+      if (!isFinite(v)) return min;
+      return Math.max(min, Math.min(max, v));
+    }
+    function lerp(a, b, t){ return a + (b - a) * t; }
+    function mapRange(v, a0, a1, b0, b1){
+      if (a1 === a0) return b0;
+      const t = (v - a0) / (a1 - a0);
+      return lerp(b0, b1, t);
+    }
+    function isFiniteNumber(v){ return typeof v === "number" && isFinite(v); }
+
+    // ---- geometry -----------------------------------------------------------
+    function computeCircularSafeArea(bounds, marginFactor){
+      const mf = (typeof marginFactor === "number") ? marginFactor : 0.08;
+      const minSide = Math.min(bounds.width, bounds.height);
+      const margin = Math.max(0, minSide * mf);
+      const r = Math.max(1, (minSide / 2) - margin);
+      const cx = bounds.x + bounds.width / 2;
+      const cy = bounds.y + bounds.height / 2;
+      return { cx, cy, radius: r };
+    }
+
+    // ---- font / text helpers -----------------------------------------------
+    function resolveFontFamily(canvas){
+      if (Helpers && typeof Helpers.resolveFontFamily === "function") {
+        return Helpers.resolveFontFamily(canvas || (canvas && canvas.canvas) || document.body);
+      }
+      const el = canvas || document.body;
+      const st = window.getComputedStyle(el);
+      const varVal = st.getPropertyValue("--dyni-font");
+      if (varVal && varVal.trim()) return varVal.trim();
+      return `"Inter","SF Pro Text",-apple-system,"Segoe UI",Roboto,"Helvetica Neue","Noto Sans",Ubuntu,Cantarell,"Liberation Sans",Arial,system-ui,"Apple Color Emoji","Segoe UI Emoji","Noto Color Emoji"`;
+    }
+
+    function setFont(ctx, sizePx, options){
+      const o = options || {};
+      const family = o.family || resolveFontFamily(ctx.canvas);
+      const weight = o.bold ? "700" : "400";
+      ctx.font = `${weight} ${sizePx}px ${family}`;
+    }
+
+    function fitTextInBox(ctx, text, box, options){
+      const o = Object.assign({ bold: true, family: resolveFontFamily(ctx.canvas) }, options || {});
+      if (!text){ return 0; }
+      const maxH = Math.max(1, box.height);
+      let px = Math.max(6, Math.floor(maxH));
+      setFont(ctx, px, { bold: o.bold, family: o.family });
+      const w = ctx.measureText(text).width;
+      if (w > box.width){
+        const scale = Math.max(0.1, box.width / Math.max(1, w));
+        px = Math.floor(px * scale);
+      }
+      px = Math.max(6, Math.min(px, Math.floor(maxH)));
+      setFont(ctx, px, { bold: o.bold, family: o.family });
+      return px;
+    }
+
+    // ---- drawing primitives -------------------------------------------------
+    function drawRing(ctx, cx, cy, radius, options){
+      const o = Object.assign({ lineWidth: 1, strokeStyle: ctx.strokeStyle }, options || {});
+      ctx.save();
+      ctx.lineWidth = o.lineWidth;
+      if (o.strokeStyle) ctx.strokeStyle = o.strokeStyle;
+      ctx.beginPath();
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2, false);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    function drawTicks(ctx, cx, cy, radiusInner, radiusOuter, ticks, options){
+      const o = Object.assign({
+        major: { len: 8, width: 2 },
+        minor: { len: 5, width: 1 },
+        strokeStyle: ctx.strokeStyle,
+        lineCap: "butt"
+      }, options || {});
+      if (!Array.isArray(ticks) || !ticks.length) return;
+      ctx.save();
+      ctx.translate(cx, cy);
+      ctx.lineCap = o.lineCap;
+
+      const minorTicks = ticks.filter(t => !t.isMajor);
+      if (minorTicks.length){
+        ctx.beginPath();
+        ctx.lineWidth = o.minor.width;
+        if (o.strokeStyle) ctx.strokeStyle = o.strokeStyle;
+        minorTicks.forEach(t => {
+          const a = t.angleRad;
+          const len = isFiniteNumber(t.len) ? t.len : o.minor.len;
+          const r1 = isFiniteNumber(radiusInner) ? radiusOuter - len : radiusOuter - len;
+          const x1 = Math.cos(a) * r1;
+          const y1 = Math.sin(a) * r1;
+          const x2 = Math.cos(a) * radiusOuter;
+          const y2 = Math.sin(a) * radiusOuter;
+          ctx.moveTo(x1, y1); ctx.lineTo(x2, y2);
+        });
+        ctx.stroke();
+      }
+
+      const majorTicks = ticks.filter(t => t.isMajor);
+      if (majorTicks.length){
+        ctx.beginPath();
+        ctx.lineWidth = o.major.width;
+        if (o.strokeStyle) ctx.strokeStyle = o.strokeStyle;
+        majorTicks.forEach(t => {
+          const a = t.angleRad;
+          const len = isFiniteNumber(t.len) ? t.len : o.major.len;
+          const r1 = isFiniteNumber(radiusInner) ? radiusOuter - len : radiusOuter - len;
+          const x1 = Math.cos(a) * r1;
+          const y1 = Math.sin(a) * r1;
+          const x2 = Math.cos(a) * radiusOuter;
+          const y2 = Math.sin(a) * radiusOuter;
+          ctx.moveTo(x1, y1); ctx.lineTo(x2, y2);
+        });
+        ctx.stroke();
+      }
+
+      ctx.restore();
+    }
+
+    function drawLabels(ctx, cx, cy, radius, labels, options){
+      const o = Object.assign({
+        fontPx: 11,
+        bold: true,
+        offset: 16,
+        textAlign: "center",
+        textBaseline: "middle",
+        fillStyle: ctx.fillStyle,
+        family: resolveFontFamily(ctx.canvas)
+      }, options || {});
+      if (!Array.isArray(labels) || !labels.length) return;
+      ctx.save();
+      ctx.textAlign = o.textAlign;
+      ctx.textBaseline = o.textBaseline;
+      if (o.fillStyle) ctx.fillStyle = o.fillStyle;
+      setFont(ctx, o.fontPx, { bold: o.bold, family: o.family });
+      labels.forEach(l => {
+        const a = l.angleRad;
+        const rr = radius - (o.offset || 0);
+        const x = cx + Math.cos(a) * rr;
+        const y = cy + Math.sin(a) * rr;
+        ctx.fillText(l.text, x, y);
+      });
+      ctx.restore();
+    }
+
+    function drawCircularSector(ctx, cx, cy, rInner, rOuter, startAngleRad, endAngleRad, options){
+      const o = Object.assign({ fillStyle: ctx.fillStyle, strokeStyle: null }, options || {});
+      ctx.save();
+      if (o.fillStyle) ctx.fillStyle = o.fillStyle;
+      if (o.strokeStyle) ctx.strokeStyle = o.strokeStyle;
+      ctx.beginPath();
+      ctx.arc(cx, cy, rOuter, startAngleRad, endAngleRad, false);
+      ctx.arc(cx, cy, Math.max(1, rInner), endAngleRad, startAngleRad, true);
+      ctx.closePath();
+      if (o.fillStyle) ctx.fill();
+      if (o.strokeStyle) ctx.stroke();
+      ctx.restore();
+    }
+
+    // ---- pointer / marker primitives ---------------------------------------
+    function drawArrow(ctx, cx, cy, rInner, rOuter, angleRad, options){
+      const o = Object.assign({ head: 8, width: 2, tail: 12, strokeStyle: null }, options || {});
+      const x2 = cx + Math.cos(angleRad) * (rOuter - 2);
+      const y2 = cy + Math.sin(angleRad) * (rOuter - 2);
+      const x1 = cx + Math.cos(angleRad) * (rInner || o.tail);
+      const y1 = cy + Math.sin(angleRad) * (rInner || o.tail);
+
+      ctx.save();
+      if (o.strokeStyle) ctx.strokeStyle = o.strokeStyle;
+      ctx.lineWidth = o.width;
+      ctx.lineCap = "round";
+      ctx.beginPath(); ctx.moveTo(x1, y1); ctx.lineTo(x2, y2); ctx.stroke();
+
+      const ah = Math.atan2(y2 - y1, x2 - x1);
+      const left = ah + Math.PI * 0.85;
+      const right = ah - Math.PI * 0.85;
+      ctx.beginPath();
+      ctx.moveTo(x2, y2);
+      ctx.lineTo(x2 + Math.cos(left) * o.head, y2 + Math.sin(left) * o.head);
+      ctx.moveTo(x2, y2);
+      ctx.lineTo(x2 + Math.cos(right) * o.head, y2 + Math.sin(right) * o.head);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    function drawPointerAtRim(ctx, cx, cy, rOuter, angleRad, options){
+      const o = Object.assign({
+        depth: Math.max(8, Math.floor(rOuter * 0.10)),
+        color: "#ff2b2b",
+        alpha: 1,
+        variant: "normal",
+        sideFactor: undefined,
+        lengthFactor: undefined
+      }, options || {});
+      let depth = Math.max(2, Math.floor(o.depth));
+      if (o.variant === "long") depth = Math.floor(depth * 1.4);
+      if (isFiniteNumber(o.lengthFactor)) depth = Math.floor(depth * o.lengthFactor);
+      const sideF = (typeof o.sideFactor === "number")
+        ? o.sideFactor
+        : (o.variant === "long" ? 0.80 : 0.65);
+      const side = Math.max(4, Math.floor(depth * sideF));
+
+      const rBase = Math.max(1, rOuter - depth);
+      const rTip  = Math.max(1, rOuter - 2);
+
+      const tipX = cx + Math.cos(angleRad) * rTip;
+      const tipY = cy + Math.sin(angleRad) * rTip;
+      const baseX = cx + Math.cos(angleRad) * rBase;
+      const baseY = cy + Math.sin(angleRad) * rBase;
+      const n = Math.atan2(tipY - baseY, tipX - baseX);
+      const l = n + Math.PI / 2;
+      const r = n - Math.PI / 2;
+
+      ctx.save();
+      ctx.globalAlpha = (typeof o.alpha === "number") ? o.alpha : 1;
+      ctx.fillStyle = o.color;
+      ctx.beginPath();
+      ctx.moveTo(tipX, tipY);
+      ctx.lineTo(baseX + Math.cos(l) * side, baseY + Math.sin(l) * side);
+      ctx.lineTo(baseX + Math.cos(r) * side, baseY + Math.sin(r) * side);
+      ctx.closePath();
+      ctx.fill();
+      ctx.restore();
+    }
+
+    function drawMarker(ctx, cx, cy, rOuter, angleRad, options){
+      const o = Object.assign({ len: 12, width: 3, strokeStyle: null }, options || {});
+      const x1 = cx + Math.cos(angleRad) * (rOuter - o.len);
+      const y1 = cy + Math.sin(angleRad) * (rOuter - o.len);
+      const x2 = cx + Math.cos(angleRad) * rOuter;
+      const y2 = cy + Math.sin(angleRad) * rOuter;
+      ctx.save();
+      if (o.strokeStyle) ctx.strokeStyle = o.strokeStyle;
+      ctx.lineWidth = o.width;
+      ctx.beginPath(); ctx.moveTo(x1, y1); ctx.lineTo(x2, y2); ctx.stroke();
+      ctx.restore();
+    }
+
+    // ---- overlays -----------------------------------------------------------
+    function drawNoDataOverlay(ctx, bounds, options){
+      const o = Object.assign({ text: "NO DATA", alpha: 0.20, fillStyle: ctx.fillStyle }, options || {});
+      ctx.save();
+      ctx.globalAlpha = o.alpha;
+      ctx.fillStyle = o.fillStyle;
+      ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+      ctx.globalAlpha = 1;
+      ctx.fillStyle = o.fillStyle;
+      const px = Math.max(12, Math.floor(Math.min(bounds.width, bounds.height) * 0.18));
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      setFont(ctx, px, { bold: true, family: resolveFontFamily(ctx.canvas) });
+      ctx.fillText(o.text, bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
+      ctx.restore();
+    }
+
+    return {
+      id: "GaugeBasicsCore",
+      version: "1.0.0",
+      clamp, lerp, mapRange, isFiniteNumber,
+      computeCircularSafeArea,
+      resolveFontFamily, setFont, fitTextInBox,
+      drawRing, drawTicks, drawLabels, drawCircularSector,
+      drawPointerAtRim, drawMarker, drawArrow,
+      drawNoDataOverlay
+    };
+  }
+
+  return { id: "GaugeBasicsCore", create };
+}));

--- a/modules/Cores/PolarCore.js
+++ b/modules/Cores/PolarCore.js
@@ -9,8 +9,11 @@
   "use strict";
 
   function create(def, Helpers) {
-    const BasicsModule = Helpers && Helpers.getModule && Helpers.getModule("GaugeBasicsCore");
-    const Basics = BasicsModule && BasicsModule.create && BasicsModule.create(def, Helpers);
+    const basicsMod = (Helpers && Helpers.getModule && Helpers.getModule("GaugeBasicsCore"))
+      || ((typeof window !== "undefined" && window.DyniModules && window.DyniModules.DyniGaugeBasicsCore)
+        ? window.DyniModules.DyniGaugeBasicsCore
+        : undefined);
+    const Basics = basicsMod && basicsMod.create && basicsMod.create(def, Helpers);
     if (!Basics) throw new Error("GaugeBasicsCore is required by PolarCore");
 
     // ---- math utils ---------------------------------------------------------

--- a/modules/Cores/PolarCore.js
+++ b/modules/Cores/PolarCore.js
@@ -1,15 +1,6 @@
 /*!
- * PolarCore (UMD) — polar math + simple compass frame helpers
- * Provides:
- *   - Angle utilities (deg/rad conversion, normalization).
- *   - Tick/label generation for 0..360° rings.
- *   - Minimal drawing helpers for polar frames, markers and arrows.
- *
- * Usage:
- *   const Polar = Helpers.getModule('PolarCore').create();
- *   const ang = Polar.norm360(hdt + offsetDeg);
+ * PolarCore (UMD) — polar math + compass helpers built atop GaugeBasicsCore
  */
-
 (function (root, factory) {
   if (typeof define === "function" && define.amd) define([], factory);
   else if (typeof module === "object" && module.exports) module.exports = factory();
@@ -17,7 +8,11 @@
 }(this, function () {
   "use strict";
 
-  function create() {
+  function create(def, Helpers) {
+    const BasicsModule = Helpers && Helpers.getModule && Helpers.getModule("GaugeBasicsCore");
+    const Basics = BasicsModule && BasicsModule.create && BasicsModule.create(def, Helpers);
+    if (!Basics) throw new Error("GaugeBasicsCore is required by PolarCore");
+
     // ---- math utils ---------------------------------------------------------
     function deg2rad(d){ return (d * Math.PI) / 180; }
     function rad2deg(r){ return (r * 180) / Math.PI; }
@@ -38,25 +33,62 @@
     }
 
     // ---- tick generation ----------------------------------------------------
-    function buildTicks(stepMajor = 30, stepMinor = 10){
-      const majors = [], minors = [];
+    function buildPolarTicks(stepMajor = 30, stepMinor = 10, rotationDeg = 0){
+      const ticks = [];
       for (let a = 0; a < 360; a += stepMinor){
-        if (a % stepMajor === 0) majors.push(a); else minors.push(a);
+        const isMajor = (a % stepMajor === 0);
+        ticks.push({ angleDeg: a, angleRad: toCanvasAngle(a, rotationDeg), isMajor });
       }
-      return { majors, minors };
+      return ticks;
     }
 
-    // ---- drawing helpers ----------------------------------------------------
-    function drawRing(ctx, cx, cy, r, opts){
+    function buildPolarLabels(step = 90, rotationDeg = 0, labels){
+      const lbls = labels || { 0:"N",90:"E",180:"S",270:"W" };
+      const out = [];
+      for (let a = 0; a < 360; a += step){
+        const text = (lbls && lbls[a] != null) ? lbls[a] : String(a);
+        out.push({ angleRad: toCanvasAngle(a, rotationDeg), text });
+      }
+      return out;
+    }
+
+    // ---- drawing ------------------------------------------------------------
+    function drawPolarFrame(ctx, bounds, options){
       const o = Object.assign({
-        strokeStyle: ctx.strokeStyle,
-        lineWidth: 1
-      }, opts || {});
-      ctx.save(); ctx.strokeStyle = o.strokeStyle; ctx.lineWidth = o.lineWidth;
-      ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI * 2, false); ctx.stroke();
-      ctx.restore();
+        ring: { lineWidth: 1 },
+        ticks: { stepMajor: 30, stepMinor: 10, major:{len:8,width:2}, minor:{len:5,width:1} },
+        labels: { fontPx: 11, bold: true, step: 90, labels: {0:"N",90:"E",180:"S",270:"W"}, offset: 16 },
+        rotationDeg: 0,
+        marginFactor: 0.08
+      }, options || {});
+
+      const safe = Basics.computeCircularSafeArea(bounds, o.marginFactor);
+      const cx = safe.cx;
+      const cy = safe.cy;
+      const r = safe.radius;
+
+      Basics.drawRing(ctx, cx, cy, r, o.ring);
+      const ticks = buildPolarTicks(o.ticks.stepMajor, o.ticks.stepMinor, o.rotationDeg);
+      Basics.drawTicks(ctx, cx, cy, r - Math.max(o.ticks.major.len, o.ticks.minor.len), r, ticks, {
+        major: { len: o.ticks.major.len, width: o.ticks.major.width },
+        minor: { len: o.ticks.minor.len, width: o.ticks.minor.width }
+      });
+      if (o.labels){
+        const labels = buildPolarLabels(o.labels.step, o.rotationDeg, o.labels.labels);
+        Basics.drawLabels(ctx, cx, cy, r, labels, {
+          fontPx: o.labels.fontPx,
+          bold: o.labels.bold,
+          offset: o.labels.offset,
+          family: o.labels.family
+        });
+      }
+      return { cx, cy, radius: r };
     }
 
+    // ---- legacy-style wrappers built atop GaugeBasics ----------------------
+    function drawRing(ctx, cx, cy, r, opts){
+      Basics.drawRing(ctx, cx, cy, r, opts);
+    }
     function drawTicks(ctx, cx, cy, r, rotationDeg, opts){
       const o = Object.assign({
         major: { len: 8, width: 2 },
@@ -64,155 +96,43 @@
         stepMajor: 30,
         stepMinor: 10
       }, opts || {});
-      const { majors, minors } = buildTicks(o.stepMajor, o.stepMinor);
-
-      ctx.save();
-      ctx.lineCap = "butt";
-      ctx.translate(cx, cy);
-
-      ctx.beginPath(); ctx.lineWidth = o.minor.width;
-      minors.forEach(a => {
-        const t = toCanvasAngle(a, rotationDeg);
-        const x1 = Math.cos(t) * (r - o.minor.len);
-        const y1 = Math.sin(t) * (r - o.minor.len);
-        const x2 = Math.cos(t) * r;
-        const y2 = Math.sin(t) * r;
-        ctx.moveTo(x1, y1); ctx.lineTo(x2, y2);
+      const ticks = buildPolarTicks(o.stepMajor, o.stepMinor, rotationDeg);
+      Basics.drawTicks(ctx, cx, cy, r - Math.max(o.major.len, o.minor.len), r, ticks, {
+        major: { len: o.major.len, width: o.major.width },
+        minor: { len: o.minor.len, width: o.minor.width }
       });
-      ctx.stroke();
-
-      ctx.beginPath(); ctx.lineWidth = o.major.width;
-      majors.forEach(a => {
-        const t = toCanvasAngle(a, rotationDeg);
-        const x1 = Math.cos(t) * (r - o.major.len);
-        const y1 = Math.sin(t) * (r - o.major.len);
-        const x2 = Math.cos(t) * r;
-        const y2 = Math.sin(t) * r;
-        ctx.moveTo(x1, y1); ctx.lineTo(x2, y2);
-      });
-      ctx.stroke();
-
-      ctx.restore();
     }
-
     function drawLabels(ctx, cx, cy, r, rotationDeg, opts){
       const o = Object.assign({
         fontPx: 11,
         bold: true,
         step: 30,
-        labels: { 0:"N",90:"E",180:"S",270:"W" }
+        labels: { 0:"N",90:"E",180:"S",270:"W" },
+        offset: 16
       }, opts || {});
-      const font = (o.bold ? "700 " : "400 ") + o.fontPx + "px " + (o.family || "sans-serif");
-      ctx.save(); ctx.font = font; ctx.textAlign = "center"; ctx.textBaseline = "middle";
-      for (let a = 0; a < 360; a += o.step) {
-        const text = (o.labels && o.labels[a] != null) ? o.labels[a] : String(a);
-        const t = toCanvasAngle(a, rotationDeg);
-        const rr = r - (o.offset || 16);
-        const x = cx + Math.cos(t) * rr;
-        const y = cy + Math.sin(t) * rr;
-        ctx.fillText(text, x, y);
-      }
-      ctx.restore();
+      const labels = buildPolarLabels(o.step, rotationDeg, o.labels);
+      Basics.drawLabels(ctx, cx, cy, r, labels, {
+        fontPx: o.fontPx,
+        bold: o.bold,
+        offset: o.offset,
+        family: o.family
+      });
     }
-
-    // Arrow with optional color; tip points outward (towards r).
     function drawArrow(ctx, cx, cy, r, angleDeg, opts){
       const o = Object.assign({ head: 8, width: 2, tail: 12, color: null, rotationDeg: 0 }, opts || {});
       const t = toCanvasAngle(angleDeg, o.rotationDeg || 0);
-      const x2 = cx + Math.cos(t) * (r - 2);
-      const y2 = cy + Math.sin(t) * (r - 2);
-      const x1 = cx + Math.cos(t) * (o.tail);
-      const y1 = cy + Math.sin(t) * (o.tail);
-
-      ctx.save();
-      if (o.color) ctx.strokeStyle = o.color;
-      ctx.lineWidth = o.width;
-      ctx.lineCap = "round";
-      ctx.beginPath(); ctx.moveTo(x1, y1); ctx.lineTo(x2, y2); ctx.stroke();
-
-      // head
-      const ah = Math.atan2(y2 - y1, x2 - x1);
-      const left = ah + Math.PI * 0.85;
-      const right = ah - Math.PI * 0.85;
-      ctx.beginPath();
-      ctx.moveTo(x2, y2);
-      ctx.lineTo(x2 + Math.cos(left) * o.head, y2 + Math.sin(left) * o.head);
-      ctx.moveTo(x2, y2);
-      ctx.lineTo(x2 + Math.cos(right) * o.head, y2 + Math.sin(right) * o.head);
-      ctx.stroke();
-      ctx.restore();
+      Basics.drawArrow(ctx, cx, cy, o.tail, r, t, { head: o.head, width: o.width, strokeStyle: o.color });
     }
-
-    // Filled triangle pointer sitting at the rim; allows an explicit color.
     function drawPointerAtRim(ctx, cx, cy, rOuter, angleDeg, opts){
-      const o = Object.assign({
-        depth: Math.max(8, Math.floor(rOuter * 0.10)),
-        color: "#ff2b2b",
-        rotationDeg: 0,
-        alpha: 1,
-        variant: "normal",
-        sideFactor: undefined,
-        lengthFactor: undefined
-      }, opts || {});
-
-      // Calculate effective depth (how far the base sits toward center)
-      let depth = Math.max(2, Math.floor(o.depth));
-      if (o.variant === "long") depth = Math.floor(depth * 1.4);           // preset for "long"
-      if (isFinite(o.lengthFactor)) depth = Math.floor(depth * o.lengthFactor); // optional fine tuning
-
-      // Base width scales with depth; use a slightly broader default for "long"
-      const sideF = (typeof o.sideFactor === "number")
-        ? o.sideFactor
-        : (o.variant === "long" ? 0.80 : 0.65);
-      const side = Math.max(4, Math.floor(depth * sideF));
-
-      // Canvas-angle (0° at 3 o'clock → rotate so that 0° shows to the top of dial)
-      // Include optional rotationDeg to allow callers to offset without changing angleDeg.
-      const aDeg = ((angleDeg + (o.rotationDeg || 0) - 90) % 360 + 360) % 360;
-      const a = (aDeg * Math.PI) / 180;
-
-      // Triangle points: tip near outer rim, base further inward
-      const rBase = Math.max(1, rOuter - depth);
-      const rTip  = Math.max(1, rOuter - 2);
-
-      const tipX = cx + Math.cos(a) * rTip;
-      const tipY = cy + Math.sin(a) * rTip;
-
-      const baseX = cx + Math.cos(a) * rBase;
-      const baseY = cy + Math.sin(a) * rBase;
-
-      // Build a symmetric base around the base point (perpendicular to pointer axis)
-      const n = Math.atan2(tipY - baseY, tipX - baseX); // axis angle
-      const l = n + Math.PI / 2;
-      const r = n - Math.PI / 2;
-
-      ctx.save();
-      ctx.globalAlpha = (typeof o.alpha === "number") ? o.alpha : 1;
-      ctx.fillStyle = o.color;
-
-      ctx.beginPath();
-      ctx.moveTo(tipX, tipY);
-      ctx.lineTo(baseX + Math.cos(l) * side, baseY + Math.sin(l) * side);
-      ctx.lineTo(baseX + Math.cos(r) * side, baseY + Math.sin(r) * side);
-      ctx.closePath();
-      ctx.fill();
-
-      ctx.restore();
-    }
-
-    function drawMarker(ctx, cx, cy, r, angleDeg, opts){
-      const o = Object.assign({ len: 12, width: 3, rotationDeg: 0 }, opts || {});
+      const o = Object.assign({ rotationDeg: 0 }, opts || {});
       const t = toCanvasAngle(angleDeg, o.rotationDeg || 0);
-      const x1 = cx + Math.cos(t) * (r - o.len);
-      const y1 = cy + Math.sin(t) * (r - o.len);
-      const x2 = cx + Math.cos(t) * r;
-      const y2 = cy + Math.sin(t) * r;
-      ctx.save();
-      ctx.lineWidth = o.width;
-      ctx.beginPath(); ctx.moveTo(x1, y1); ctx.lineTo(x2, y2); ctx.stroke();
-      ctx.restore();
+      Basics.drawPointerAtRim(ctx, cx, cy, rOuter, t, o);
     }
-
+    function drawMarker(ctx, cx, cy, r, angleDeg, opts){
+      const o = Object.assign({ rotationDeg: 0 }, opts || {});
+      const t = toCanvasAngle(angleDeg, o.rotationDeg || 0);
+      Basics.drawMarker(ctx, cx, cy, r, t, o);
+    }
     function drawFrame(ctx, cx, cy, r, opts){
       const o = Object.assign({
         ring: { lineWidth: 1 },
@@ -220,19 +140,17 @@
         labels: { fontPx: 11, bold: true, step: 90, labels: {0:"N",90:"E",180:"S",270:"W"}, offset: 16 },
         rotationDeg: 0
       }, opts || {});
-
       drawRing(ctx, cx, cy, r, o.ring);
       drawTicks(ctx, cx, cy, r, o.rotationDeg, o.ticks);
       if (o.labels) drawLabels(ctx, cx, cy, r, o.rotationDeg, o.labels);
     }
 
-    return {
+      return {
       id: "PolarCore",
-      version: "1.1.0",
-      // math
+      version: "2.0.0",
       deg2rad, rad2deg, norm360, norm180, toCanvasAngle,
-      // ticks & labels
-      buildTicks, drawRing, drawTicks, drawLabels, drawMarker, drawArrow, drawPointerAtRim, drawFrame
+      buildPolarTicks, buildPolarLabels, drawPolarFrame,
+      drawRing, drawTicks, drawLabels, drawMarker, drawArrow, drawPointerAtRim, drawFrame
     };
   }
 

--- a/modules/Cores/RadialGaugeCore.js
+++ b/modules/Cores/RadialGaugeCore.js
@@ -9,10 +9,16 @@
   "use strict";
 
   function create(def, Helpers) {
-    const BasicsMod = Helpers && Helpers.getModule && Helpers.getModule("GaugeBasicsCore");
-    const Basics = BasicsMod && BasicsMod.create && BasicsMod.create(def, Helpers);
-    const PolarMod = Helpers && Helpers.getModule && Helpers.getModule("PolarCore");
-    const Polar = PolarMod && PolarMod.create && PolarMod.create(def, Helpers);
+    const basicsMod = (Helpers && Helpers.getModule && Helpers.getModule("GaugeBasicsCore"))
+      || ((typeof window !== "undefined" && window.DyniModules && window.DyniModules.DyniGaugeBasicsCore)
+        ? window.DyniModules.DyniGaugeBasicsCore
+        : undefined);
+    const Basics = basicsMod && basicsMod.create && basicsMod.create(def, Helpers);
+    const polarMod = (Helpers && Helpers.getModule && Helpers.getModule("PolarCore"))
+      || ((typeof window !== "undefined" && window.DyniModules && window.DyniModules.DyniPolarCore)
+        ? window.DyniModules.DyniPolarCore
+        : undefined);
+    const Polar = polarMod && polarMod.create && polarMod.create(def, Helpers);
     if (!Basics || !Polar) throw new Error("RadialGaugeCore needs GaugeBasicsCore and PolarCore");
 
     function resolveColor(ctx, varNames, fallback){

--- a/modules/Cores/RadialGaugeCore.js
+++ b/modules/Cores/RadialGaugeCore.js
@@ -1,0 +1,208 @@
+/*!
+ * RadialGaugeCore (UMD) — semicircular radial gauge built on GaugeBasicsCore + PolarCore
+ */
+(function (root, factory) {
+  if (typeof define === "function" && define.amd) define([], factory);
+  else if (typeof module === "object" && module.exports) module.exports = factory();
+  else { (root.DyniModules = root.DyniModules || {}).DyniRadialGaugeCore = factory(); }
+}(this, function () {
+  "use strict";
+
+  function create(def, Helpers) {
+    const BasicsMod = Helpers && Helpers.getModule && Helpers.getModule("GaugeBasicsCore");
+    const Basics = BasicsMod && BasicsMod.create && BasicsMod.create(def, Helpers);
+    const PolarMod = Helpers && Helpers.getModule && Helpers.getModule("PolarCore");
+    const Polar = PolarMod && PolarMod.create && PolarMod.create(def, Helpers);
+    if (!Basics || !Polar) throw new Error("RadialGaugeCore needs GaugeBasicsCore and PolarCore");
+
+    function resolveColor(ctx, varNames, fallback){
+      const st = window.getComputedStyle(ctx.canvas);
+      for (const v of varNames){
+        const val = st.getPropertyValue(v).trim();
+        if (val) return val;
+      }
+      return fallback || st.color || "#000";
+    }
+
+    function resolveStyle(ctx, mode, overrides){
+      const fg = resolveColor(ctx, ["--instrument-fg","--dyni-fg","--mainfg"], "#e0e0e0");
+      const base = {
+        fgColor: fg,
+        bgColor: resolveColor(ctx, ["--instrument-bg","--dyni-bg"], "#000"),
+        tickColor: fg,
+        labelColor: fg,
+        valueColor: fg,
+        captionColor: fg,
+        warningColor: "#f3c500",
+        alarmColor: "#ff2b2b",
+        rimLineWidth: 1,
+        tickLineWidth: 1,
+        fontFamily: Basics.resolveFontFamily(ctx.canvas),
+        needleWidth: 2.5
+      };
+      const m = mode || "normal";
+      if (m === "flat") {
+        base.rimLineWidth = 1;
+        base.tickLineWidth = 1;
+      } else if (m === "high") {
+        base.rimLineWidth = 2;
+        base.tickLineWidth = 2;
+      }
+      return Object.assign(base, overrides || {});
+    }
+
+    function valueToCanvasAngle(v, cfg){
+      const hasVal = Basics.isFiniteNumber(v);
+      if (!hasVal) return null;
+      const clamped = Basics.clamp(v, cfg.minValue, cfg.maxValue);
+      const t = Basics.mapRange(clamped, cfg.minValue, cfg.maxValue, 0, 1);
+      const angleDeg = Basics.lerp(cfg.startAngleDeg, cfg.endAngleDeg, t);
+      return Polar.toCanvasAngle(angleDeg, 0);
+    }
+
+    function buildTicks(cfg){
+      const ticks = [];
+      const majorStep = cfg.majorTickStep || 30;
+      const minorStep = cfg.minorTickStep || 10;
+      for (let v = cfg.minValue; v <= cfg.maxValue + 1e-6; v += minorStep){
+        const isMajor = Math.abs((v - cfg.minValue) % majorStep) < 1e-6;
+        const angleRad = valueToCanvasAngle(v, cfg);
+        ticks.push({ angleRad, isMajor });
+      }
+      return ticks;
+    }
+
+    function buildLabels(cfg){
+      const labels = [];
+      if (!Basics.isFiniteNumber(cfg.labelStep) || cfg.labelStep <= 0) return labels;
+      for (let v = cfg.minValue; v <= cfg.maxValue + 1e-6; v += cfg.labelStep){
+        const angleRad = valueToCanvasAngle(v, cfg);
+        labels.push({ angleRad, text: String(Math.round(v)) });
+      }
+      return labels;
+    }
+
+    function drawRadialGauge(ctx, bounds, config){
+      const cfg = Object.assign({
+        minValue: 0,
+        maxValue: 100,
+        value: null,
+        startAngleDeg: -90,
+        endAngleDeg: 90,
+        majorTickStep: 30,
+        minorTickStep: 10,
+        labelStep: 30,
+        caption: "",
+        unit: "",
+        showValue: true,
+        mode: "normal",
+        marginFactor: 0.08
+      }, config || {});
+      const style = resolveStyle(ctx, cfg.mode, cfg.style);
+
+      const minSide = Math.min(bounds.width, bounds.height);
+      const margin = Math.max(0, (cfg.marginFactor || 0) * minSide);
+      const radius = Math.max(1, Math.min((bounds.width - 2*margin)/2, bounds.height - 2*margin));
+      const cx = bounds.x + bounds.width / 2;
+      const cy = bounds.y + margin + radius;
+
+      ctx.save();
+      ctx.strokeStyle = style.fgColor;
+      ctx.fillStyle = style.fgColor;
+
+      const hasValue = Basics.isFiniteNumber(cfg.value);
+
+      // Rim
+      ctx.beginPath();
+      const startRad = Polar.toCanvasAngle(cfg.startAngleDeg, 0);
+      const endRad = Polar.toCanvasAngle(cfg.endAngleDeg, 0);
+      const anticlockwise = startRad > endRad;
+      ctx.lineWidth = style.rimLineWidth;
+      ctx.arc(cx, cy, radius, startRad, endRad, anticlockwise);
+      ctx.stroke();
+
+      // Warning/alarm sectors
+      if (cfg.warningSector){
+        const from = Basics.clamp(cfg.warningSector.from, cfg.minValue, cfg.maxValue);
+        const to = Basics.clamp(cfg.warningSector.to, cfg.minValue, cfg.maxValue);
+        const a0 = valueToCanvasAngle(from, cfg);
+        const a1 = valueToCanvasAngle(to, cfg);
+        Basics.drawCircularSector(ctx, cx, cy, radius*0.88, radius*0.98, a0, a1, { fillStyle: style.warningColor });
+      }
+      if (cfg.alarmSector){
+        const from = Basics.clamp(cfg.alarmSector.from, cfg.minValue, cfg.maxValue);
+        const to = Basics.clamp(cfg.alarmSector.to, cfg.minValue, cfg.maxValue);
+        const a0 = valueToCanvasAngle(from, cfg);
+        const a1 = valueToCanvasAngle(to, cfg);
+        Basics.drawCircularSector(ctx, cx, cy, radius*0.88, radius*0.98, a0, a1, { fillStyle: style.alarmColor });
+      }
+
+      // Ticks & labels
+      const ticks = buildTicks(cfg);
+      Basics.drawTicks(ctx, cx, cy, radius*0.85, radius, ticks, {
+        major: { len: Math.max(8, Math.floor(radius*0.08)), width: style.tickLineWidth*2 },
+        minor: { len: Math.max(5, Math.floor(radius*0.05)), width: style.tickLineWidth },
+        strokeStyle: style.tickColor
+      });
+      const labels = buildLabels(cfg);
+      if (labels.length){
+        Basics.drawLabels(ctx, cx, cy, radius, labels, {
+          fontPx: Math.max(10, Math.floor(radius*0.12)),
+          bold: true,
+          offset: Math.max(16, Math.floor(radius*0.18)),
+          fillStyle: style.labelColor,
+          family: style.fontFamily
+        });
+      }
+
+      // Needle
+      if (hasValue){
+        const ang = valueToCanvasAngle(cfg.value, cfg);
+        Basics.drawPointerAtRim(ctx, cx, cy, radius, ang, {
+          color: style.fgColor,
+          alpha: 1,
+          variant: cfg.mode === "high" ? "long" : "normal"
+        });
+      }
+
+      // Text layout
+      const textTop = cy;
+      const availableH = bounds.y + bounds.height - textTop - margin * 0.2;
+      const valueBox = { x: bounds.x + margin, y: textTop + availableH*0.05, width: bounds.width - 2*margin, height: availableH*0.6 };
+      const captionBox = { x: bounds.x + margin, y: valueBox.y + valueBox.height, width: bounds.width - 2*margin, height: availableH*0.35 };
+
+      if (hasValue && cfg.showValue !== false){
+        const valText = String(Math.round(Basics.clamp(cfg.value, cfg.minValue, cfg.maxValue) * 10) / 10);
+        const unitText = cfg.unit || "";
+        const valSize = Basics.fitTextInBox(ctx, valText, valueBox, { bold: true, family: style.fontFamily });
+        ctx.textAlign = "center"; ctx.textBaseline = "top"; ctx.fillStyle = style.valueColor;
+        Basics.setFont(ctx, valSize, { bold: true, family: style.fontFamily });
+        ctx.fillText(valText, valueBox.x + valueBox.width/2, valueBox.y);
+        if (unitText){
+          const unitBox = { x: valueBox.x + valueBox.width*0.1, y: valueBox.y + valSize, width: valueBox.width*0.8, height: valueBox.height - valSize };
+          const unitSize = Basics.fitTextInBox(ctx, unitText, unitBox, { bold: true, family: style.fontFamily });
+          Basics.setFont(ctx, unitSize, { bold: true, family: style.fontFamily });
+          ctx.fillText(unitText, unitBox.x + unitBox.width/2, unitBox.y);
+        }
+      }
+
+      if (cfg.caption){
+        ctx.fillStyle = style.captionColor;
+        const capSize = Basics.fitTextInBox(ctx, cfg.caption, captionBox, { bold: true, family: style.fontFamily });
+        ctx.textAlign = "center"; ctx.textBaseline = "top";
+        Basics.setFont(ctx, capSize, { bold: true, family: style.fontFamily });
+        ctx.fillText(cfg.caption, captionBox.x + captionBox.width/2, captionBox.y);
+      }
+
+      if (!hasValue){
+        Basics.drawNoDataOverlay(ctx, bounds, { text: "NO DATA", fillStyle: style.fgColor });
+      }
+
+      ctx.restore();
+    }
+
+    return { id: "RadialGaugeCore", version: "1.0.0", drawRadialGauge };
+  }
+
+  return { id: "RadialGaugeCore", create };
+}));

--- a/modules/WindDial/WindDial.js
+++ b/modules/WindDial/WindDial.js
@@ -22,7 +22,10 @@
   "use strict";
 
   function create(def, Helpers) {
-    const Polar = Helpers.getModule('PolarCore') && Helpers.getModule('PolarCore').create();
+    const PolarModule = Helpers.getModule('PolarCore');
+    const Polar = PolarModule && typeof PolarModule.create === 'function'
+      ? PolarModule.create(def, Helpers)
+      : undefined;
 
     // --------- util ----------------------------------------------------------
     function setFont(ctx, px, bold, family){ ctx.font = (bold ? '700 ' : '400 ') + px + 'px ' + family; }

--- a/plugin.js
+++ b/plugin.js
@@ -131,8 +131,9 @@
 
   // ---------- Module registry (UMD namespaces + deps) -----------------------
   const MODULES = {
-    PolarCore: { js:  BASE + "modules/Cores/PolarCore.js", css: undefined, globalKey: "DyniPolarCore" },
-    RadialGaugeCore: { js:  BASE + "modules/Cores/RadialGaugeCore.js", css: undefined, globalKey: "DyniRadialGaugeCore" },
+    GaugeBasicsCore: { js: BASE + "modules/Cores/GaugeBasicsCore.js", css: undefined, globalKey: "DyniGaugeBasicsCore" },
+    PolarCore: { js:  BASE + "modules/Cores/PolarCore.js", css: undefined, globalKey: "DyniPolarCore", deps: ["GaugeBasicsCore"] },
+    RadialGaugeCore: { js:  BASE + "modules/Cores/RadialGaugeCore.js", css: undefined, globalKey: "DyniRadialGaugeCore", deps: ["GaugeBasicsCore","PolarCore"] },
     ListCore: { js:  BASE + "modules/Cores/ListCore.js", css: BASE + "modules/Cores/ListCore.css", globalKey: "DyniListCore" },
     MiniHistory: { js:  BASE + "modules/Cores/MiniHistory.js", css: undefined, globalKey: "DyniMiniHistory" },
 


### PR DESCRIPTION
## Summary
- add a shared GaugeBasicsCore with reusable math, font, and drawing helpers
- refactor PolarCore to lean on GaugeBasicsCore while keeping legacy drawing wrappers
- introduce a semicircular RadialGaugeCore and register new cores in the module map

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ad2816118832abb962ef04696229d)