### PR TITLE
Remove UMD fallbacks for core modules

### DIFF
--- a/modules/Cores/PolarCore.js
+++ b/modules/Cores/PolarCore.js
@@ -9,10 +9,7 @@
   "use strict";
 
   function create(def, Helpers) {
-    const basicsMod = (Helpers && Helpers.getModule && Helpers.getModule("GaugeBasicsCore"))
-      || ((typeof window !== "undefined" && window.DyniModules && window.DyniModules.DyniGaugeBasicsCore)
-        ? window.DyniModules.DyniGaugeBasicsCore
-        : undefined);
+    const basicsMod = Helpers && Helpers.getModule && Helpers.getModule("GaugeBasicsCore");
     const Basics = basicsMod && basicsMod.create && basicsMod.create(def, Helpers);
     if (!Basics) throw new Error("GaugeBasicsCore is required by PolarCore");
 

--- a/modules/Cores/RadialGaugeCore.js
+++ b/modules/Cores/RadialGaugeCore.js
@@ -9,15 +9,9 @@
   "use strict";
 
   function create(def, Helpers) {
-    const basicsMod = (Helpers && Helpers.getModule && Helpers.getModule("GaugeBasicsCore"))
-      || ((typeof window !== "undefined" && window.DyniModules && window.DyniModules.DyniGaugeBasicsCore)
-        ? window.DyniModules.DyniGaugeBasicsCore
-        : undefined);
+    const basicsMod = Helpers && Helpers.getModule && Helpers.getModule("GaugeBasicsCore");
     const Basics = basicsMod && basicsMod.create && basicsMod.create(def, Helpers);
-    const polarMod = (Helpers && Helpers.getModule && Helpers.getModule("PolarCore"))
-      || ((typeof window !== "undefined" && window.DyniModules && window.DyniModules.DyniPolarCore)
-        ? window.DyniModules.DyniPolarCore
-        : undefined);
+    const polarMod = Helpers && Helpers.getModule && Helpers.getModule("PolarCore");
     const Polar = polarMod && polarMod.create && polarMod.create(def, Helpers);
     if (!Basics || !Polar) throw new Error("RadialGaugeCore needs GaugeBasicsCore and PolarCore");
 


### PR DESCRIPTION
## Summary
- remove window-based fallback module lookups from PolarCore and RadialGaugeCore
- rely on Helpers.getModule to resolve GaugeBasicsCore and PolarCore as intended

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b312f8834832abe01aeda30bcf507)